### PR TITLE
Allow AJAX requests in admin with HTTPS

### DIFF
--- a/app/Plugin/Admin/View/Layouts/default.ctp
+++ b/app/Plugin/Admin/View/Layouts/default.ctp
@@ -13,7 +13,7 @@
     <meta charset="UTF-8">
 
     <script language="javascript">
-        <?php echo "var site_url = 'http://".$_SERVER['HTTP_HOST'].$this->webroot."';"?>
+        <?php echo "var site_url = '".$this->Tools->getProtocol().$_SERVER['HTTP_HOST'].$this->webroot."';"?>
         <?php echo "var controller = '".strtolower($this->name)."';"?>        
         <?php echo "var imgLoading = '".$this->Html->image('/img/loading.gif', array('alt' => 'loading', 'title' => 'Loading...', 'class' => 'loading'))."';"?>
         <?php echo "var mushraiderVersion = '".Configure::read('mushraider.version')."';"?>        


### PR DESCRIPTION
Hi,

Today I tried to install Mushraider and had a problem with AJAX and HTTPS.
It prevented me first to import settings for a game through Redhead API for my Mushraider instance running with HTTPS.

This was because of the web browser preventing AJAX calls to HTTP resources on a page loaded over HTTPS.

This patch will fix the problem the same way it is done in the general layout in `app/View/Layouts/default.ctp `.

Hope you will like it!