### PR TITLE
Allow the Bridge code to display error messages to the user

### DIFF
--- a/app/Controller/AuthController.php
+++ b/app/Controller/AuthController.php
@@ -50,7 +50,8 @@ class AuthController extends AppController {
                 $auth = $HttpSocket->post($this->bridge->url, array('login' => $this->request->data['User']['login'], 'pwd' => $pwd));
                 $auth = json_decode($auth->body);
                 if(empty($auth) || !$auth->authenticated) {
-                    $this->Session->setFlash(__('The email or password that you entered is incorrect'), 'flash_warning');
+                    $message = empty($auth->error) ? 'The email or password that you entered is incorrect' : $auth->error;
+                    $this->Session->setFlash(__($message), 'flash_warning');
                     unset($this->request->data['User']);
                 }else {
                     $roleId = !empty($auth->role)?$this->Role->getIdByAlias($auth->role):null;


### PR DESCRIPTION
In some cases, it can be useful for the Bridge code to return an explicit error message to the user in case of authentication failure. Currently, MushRaider only says “The email or password that you entered is incorrect”. This can now be accomplished by returning an ‘error’ field in the JSON output that contains the error message to display.

Of course, it is the Bridge developer’s responsibility to send something meaningful and not expose any secret or inner working of the Bridge code or the server settings.

If the ‘error’ field is not returned, the original MushRaider message will be shown.