### PR TITLE
Fix raidhead datasource

### DIFF
--- a/app/Config/core.php
+++ b/app/Config/core.php
@@ -32,13 +32,13 @@
  *
  * In production mode, flash messages redirect after a time interval.
  * In development mode, you need to click the flash message to continue.
- */	
+ */
 
 // TODO : generate config.salt.php
 
 
 	Configure::write('debug', 0);
-	Configure::write('mushraider', array('version' => '1.7.0.2', 'date' => '2017-02-19'));
+	Configure::write('mushraider', array('version' => '1.7.0.3', 'date' => '2019-01-17'));
 
 /**
  * Configure the Error handler used to handle errors for your application. By default

--- a/app/Model/Datasource/RaidheadSource.php
+++ b/app/Model/Datasource/RaidheadSource.php
@@ -29,6 +29,35 @@ class RaidheadSource extends DataSource {
 		$this->config['baseUrl'] .= $lang;
 	}
 
+	/**
+	 * query api and return response as array or false
+	 * @param  string $uri api uri
+	 * @return array|false response as array or false if failed
+	 */
+	private function _get($uri)
+	{
+		$client = new HttpSocket([
+			'request' => [
+				'redirect' => 2,
+			],
+		]);
+
+		try {
+			$response = $client->get([
+				'uri' => $this->config['baseUrl'] . $uri,
+				'header' => [
+					'User-Agent' => 'Mushraider',
+				],
+			]);
+
+			$return = json_decode($response, true);
+		} catch (Exception $e) {
+			$return = false;
+		}
+
+		return $return;
+	}
+
 	public function gets($type = 'all') {
 		$list = array();
 		$json = $this->http->get($this->config['baseUrl'].'/games/index.json');

--- a/app/Model/Datasource/RaidheadSource.php
+++ b/app/Model/Datasource/RaidheadSource.php
@@ -18,7 +18,6 @@ class RaidheadSource extends DataSource {
 		'langs' => array('eng', 'fra')
 	);
 
-
 	public function __construct() {
 		$lang = strtolower(Configure::read('Settings.language'));
 		if(!in_array($lang, $this->config['langs'])) {

--- a/app/Model/Datasource/RaidheadSource.php
+++ b/app/Model/Datasource/RaidheadSource.php
@@ -18,10 +18,8 @@ class RaidheadSource extends DataSource {
 		'langs' => array('eng', 'fra')
 	);
 
-	private $http;
 
 	public function __construct() {
-		$this->http = new HttpSocket();
 		$lang = strtolower(Configure::read('Settings.language'));
 		if(!in_array($lang, $this->config['langs'])) {
 			$lang = $this->config['langs'][0];
@@ -60,7 +58,6 @@ class RaidheadSource extends DataSource {
 
 	public function gets($type = 'all') {
 		$list = array();
-		$json = $this->http->get($this->config['baseUrl'].'/games/index.json');
 		$games = $this->_get('/games/index.json');
 		if($games === false) {
 			$error = json_last_error();
@@ -81,9 +78,8 @@ class RaidheadSource extends DataSource {
 	}
 
 	public function get($slug) {
-		$json = $this->http->get($this->config['baseUrl'].'/games/get/'.$slug.'.json');
-		$game = json_decode($json, true);
-		if(is_null($game)) {
+		$game = $this->_get('/games/get/' . $slug . '.json');
+		if($game === false) {
 			$error = json_last_error();
 			throw new CakeException($error);
 		}
@@ -92,9 +88,8 @@ class RaidheadSource extends DataSource {
 	}
 
 	public function serverStatus($slug) {
-		$json = $this->http->get($this->config['baseUrl'].'/server_status/get/'.$slug.'.json');
-		$serverStatus = json_decode($json, true);
-		if(is_null($serverStatus)) {
+		$serverStatus = $this->_get('/server_status/get/' . $slug . '.json');
+		if($serverStatus === false) {
 			$error = json_last_error();
 			throw new CakeException($error);
 		}

--- a/app/Model/Datasource/RaidheadSource.php
+++ b/app/Model/Datasource/RaidheadSource.php
@@ -6,70 +6,70 @@
  * @desc Used for reading from RaidHead API.
  *
  */
- 
+
 App::uses('DataSource', 'Model/Datasource');
 App::uses('HttpSocket', 'Network/Http');
 
 class RaidheadSource extends DataSource {
 
-    public $config = array(
-        'baseUrl' => 'http://api.raidhead.com/',
-        'langs' => array('eng', 'fra')
-    );
+	public $config = array(
+		'baseUrl' => 'http://api.raidhead.com/',
+		'langs' => array('eng', 'fra')
+	);
 
-    private $http;
+	private $http;
 
-    public function __construct() {
-        $this->http = new HttpSocket();
-        $lang = strtolower(Configure::read('Settings.language'));
-        if(!in_array($lang, $this->config['langs'])) {
-            $lang = $this->config['langs'][0];
-        }
+	public function __construct() {
+		$this->http = new HttpSocket();
+		$lang = strtolower(Configure::read('Settings.language'));
+		if(!in_array($lang, $this->config['langs'])) {
+			$lang = $this->config['langs'][0];
+		}
 
-        $this->config['baseUrl'] .= $lang;
-    }
-    
-    public function gets($type = 'all') {
-        $list = array();
-        $json = $this->http->get($this->config['baseUrl'].'/games/index.json');
-        $games = json_decode($json, true);
-        if(is_null($games)) {
-            $error = json_last_error();
-            throw new CakeException($error);
-        }
+		$this->config['baseUrl'] .= $lang;
+	}
 
-        if($type == 'list') {
-            if(!empty($games)) {
-                foreach($games as $game) {
-                    $list[$game['short']] = $game['title'];
-                }
-            }
+	public function gets($type = 'all') {
+		$list = array();
+		$json = $this->http->get($this->config['baseUrl'].'/games/index.json');
+		$games = json_decode($json, true);
+		if(is_null($games)) {
+			$error = json_last_error();
+			throw new CakeException($error);
+		}
 
-            return $list;
-        }
+		if($type == 'list') {
+			if(!empty($games)) {
+				foreach($games as $game) {
+					$list[$game['short']] = $game['title'];
+				}
+			}
 
-        return $games;
-    }
+			return $list;
+		}
 
-    public function get($slug) {
-        $json = $this->http->get($this->config['baseUrl'].'/games/get/'.$slug.'.json');
-        $game = json_decode($json, true);
-        if(is_null($game)) {
-            $error = json_last_error();
-            throw new CakeException($error);
-        }
+		return $games;
+	}
 
-        return $game;
-    }
+	public function get($slug) {
+		$json = $this->http->get($this->config['baseUrl'].'/games/get/'.$slug.'.json');
+		$game = json_decode($json, true);
+		if(is_null($game)) {
+			$error = json_last_error();
+			throw new CakeException($error);
+		}
 
-    public function serverStatus($slug) {
-        $json = $this->http->get($this->config['baseUrl'].'/server_status/get/'.$slug.'.json');
-        $serverStatus = json_decode($json, true);
-        if(is_null($serverStatus)) {
-            $error = json_last_error();
-            throw new CakeException($error);
-        }
+		return $game;
+	}
 
-        return $serverStatus;
-    }
+	public function serverStatus($slug) {
+		$json = $this->http->get($this->config['baseUrl'].'/server_status/get/'.$slug.'.json');
+		$serverStatus = json_decode($json, true);
+		if(is_null($serverStatus)) {
+			$error = json_last_error();
+			throw new CakeException($error);
+		}
+
+		return $serverStatus;
+	}
 }

--- a/app/Model/Datasource/RaidheadSource.php
+++ b/app/Model/Datasource/RaidheadSource.php
@@ -9,6 +9,7 @@
 
 App::uses('DataSource', 'Model/Datasource');
 App::uses('HttpSocket', 'Network/Http');
+App::uses('Configure', 'Core');
 
 class RaidheadSource extends DataSource {
 
@@ -43,14 +44,13 @@ class RaidheadSource extends DataSource {
 		]);
 
 		try {
-			$response = $client->get([
-				'uri' => $this->config['baseUrl'] . $uri,
+			$response = $client->get($this->config['baseUrl'] . $uri, [], [
 				'header' => [
-					'User-Agent' => 'Mushraider',
+					'User-Agent' => 'Mushraider/' . Configure::read('mushraider.version'),
 				],
 			]);
 
-			$return = json_decode($response, true);
+			$return = json_decode($response->body(), true);
 		} catch (Exception $e) {
 			$return = false;
 		}
@@ -61,8 +61,8 @@ class RaidheadSource extends DataSource {
 	public function gets($type = 'all') {
 		$list = array();
 		$json = $this->http->get($this->config['baseUrl'].'/games/index.json');
-		$games = json_decode($json, true);
-		if(is_null($games)) {
+		$games = $this->_get('/games/index.json');
+		if($games === false) {
 			$error = json_last_error();
 			throw new CakeException($error);
 		}

--- a/app/Model/Datasource/RaidheadSource.php
+++ b/app/Model/Datasource/RaidheadSource.php
@@ -14,7 +14,7 @@ App::uses('Configure', 'Core');
 class RaidheadSource extends DataSource {
 
 	public $config = array(
-		'baseUrl' => 'http://api.raidhead.com/',
+		'baseUrl' => 'https://api.raidhead.com/',
 		'langs' => array('eng', 'fra')
 	);
 


### PR DESCRIPTION
Apport des modifications sur App\Model\RaidheadSource :
- utilisation de https par défaut
- client http tout neuf à chaque requête (fix ssl:// on port 80 in case of redirect)
- méthode _get() gère les erreurs et retourne forcément un tableau
- User-Agent défini à `Mushraider/<version>`
- bump de la version en 1.7.0.3